### PR TITLE
Add execute permission to datasource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,7 @@ COPY redis-app $GF_PATHS_PLUGINS/redis-app
 
 # Provisioning
 COPY provisioning/plugins $GF_PATHS_PROVISIONING/plugins
+
+# Add Execute permissions
+
+RUN chmod +x $GF_PATHS_PLUGINS/redis-datasource/redis-datasource*


### PR DESCRIPTION
Datasource binaries don't have an `execute` flag after uploading/downloading as an artifact.

```
t=2021-01-27T21:57:41+0000 lvl=info msg="Starting plugin search" logger=plugins
t=2021-01-27T21:57:41+0000 lvl=info msg="Registering plugin" logger=plugins id=input
t=2021-01-27T21:57:41+0000 lvl=info msg="Registering plugin" logger=plugins id=redis-cli-panel
t=2021-01-27T21:57:41+0000 lvl=info msg="Registering plugin" logger=plugins id=redis-gears-panel
t=2021-01-27T21:57:41+0000 lvl=info msg="Registering plugin" logger=plugins id=redis-keys-panel
t=2021-01-27T21:57:41+0000 lvl=info msg="Registering plugin" logger=plugins id=redis-latency-panel
t=2021-01-27T21:57:41+0000 lvl=info msg="Registering plugin" logger=plugins id=redis-datasource
t=2021-01-27T21:57:41+0000 lvl=info msg="Registering plugin" logger=plugins id=redis-explorer-app
t=2021-01-27T21:57:41+0000 lvl=info msg="Registering plugin" logger=plugins id=redis-enterprise-software-datasource
t=2021-01-27T21:57:41+0000 lvl=info msg="Registering plugin" logger=plugins id=redis-app
t=2021-01-27T21:57:41+0000 lvl=info msg="Updating app from configuration " logger=provisioning.plugins type=redis-app enabled=true
t=2021-01-27T21:57:41+0000 lvl=info msg="Plugin state changed" logger=plugins pluginId=redis-app enabled=true
t=2021-01-27T21:57:41+0000 lvl=info msg="Syncing plugin dashboards to DB" logger=plugins pluginId=redis-app
t=2021-01-27T21:57:41+0000 lvl=info msg="Auto updating App dashboard" logger=plugins dashboard="Redis CLI" newRev=1 oldRev=0
t=2021-01-27T21:57:42+0000 lvl=info msg="Auto updating App dashboard" logger=plugins dashboard="Redis Overview" newRev=1 oldRev=0
t=2021-01-27T21:57:42+0000 lvl=info msg="Auto updating App dashboard" logger=plugins dashboard=RedisGears newRev=1 oldRev=0
t=2021-01-27T21:57:42+0000 lvl=info msg="Updating app from configuration " logger=provisioning.plugins type=redis-explorer-app enabled=true
t=2021-01-27T21:57:42+0000 lvl=info msg="Plugin state changed" logger=plugins pluginId=redis-explorer-app enabled=true
t=2021-01-27T21:57:42+0000 lvl=info msg="Syncing plugin dashboards to DB" logger=plugins pluginId=redis-explorer-app
t=2021-01-27T21:57:42+0000 lvl=info msg="Auto updating App dashboard" logger=plugins dashboard="Enterprise Clusters" newRev=1 oldRev=0
t=2021-01-27T21:57:42+0000 lvl=info msg="Auto updating App dashboard" logger=plugins dashboard="Cluster Overview" newRev=1 oldRev=0
t=2021-01-27T21:57:42+0000 lvl=info msg="Auto updating App dashboard" logger=plugins dashboard="Cluster Nodes" newRev=1 oldRev=0
t=2021-01-27T21:57:42+0000 lvl=info msg="Auto updating App dashboard" logger=plugins dashboard="Cluster Databases" newRev=1 oldRev=0
t=2021-01-27T21:57:42+0000 lvl=info msg="Auto updating App dashboard" logger=plugins dashboard="Cluster Settings" newRev=1 oldRev=0
t=2021-01-27T21:57:42+0000 lvl=eror msg="Failed to start plugin" logger=plugins.backend pluginId=redis-datasource error="fork/exec /var/lib/grafana/plugins/redis-datasource/redis-datasource_linux_amd64: permission denied"
t=2021-01-27T21:57:42+0000 lvl=info msg="HTTP Server Listen" logger=http.server address=[::]:3000 protocol=http subUrl= socket=
```